### PR TITLE
feat: allow omitting of dates from date ranges

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -150,7 +150,7 @@
                 ]
                 // Line 2: Degree and Date Range
                 #text(style: "italic")[#edu.studyType in #edu.area] #h(1fr)
-                #start #sym.dash.en #end \
+                #utils.daterange(start, end) \
                 #eval(edu-items, mode: "markup")
             ]
         }
@@ -175,7 +175,7 @@
                 ]
                 // Line 2: Degree and Date Range
                 #text(style: "italic")[#w.position] #h(1fr)
-                #start #sym.dash.en #end \
+                #utils.daterange(start, end) \
                 // Highlights or Description
                 #for hi in w.highlights [
                     - #eval(hi, mode: "markup")
@@ -204,7 +204,7 @@
                 ]
                 // Line 2: Degree and Date Range
                 #text(style: "italic")[#org.position] #h(1fr)
-                #start #sym.dash.en #end \
+                #utils.daterange(start, end) \
                 // Highlights or Description
                 #if org.highlights != none {
                     for hi in org.highlights [
@@ -233,7 +233,7 @@
                     *#project.name* \
                 ]
                 // Line 2: Degree and Date Range
-                #text(style: "italic")[#project.affiliation]  #h(1fr) #start #sym.dash.en #end \
+                #text(style: "italic")[#project.affiliation]  #h(1fr) #utils.daterange(start, end) \
                 // Summary or Description
                 #for hi in project.highlights [
                     - #eval(hi, mode: "markup")

--- a/cv.typ.schema.json
+++ b/cv.typ.schema.json
@@ -265,7 +265,7 @@
                         ]
                     },
                     "startDate": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "format": "date",
                         "title": "The startDate Schema",
                         "examples": [
@@ -273,7 +273,7 @@
                         ]
                     },
                     "endDate": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "title": "The endDate Schema",
                         "examples": [
                             "present",
@@ -420,7 +420,7 @@
                         ]
                     },
                     "startDate": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "format": "date",
                         "title": "The startDate Schema",
                         "examples": [
@@ -428,7 +428,7 @@
                         ]
                     },
                     "endDate": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "title": "The endDate Schema",
                         "examples": [
                             "2021-06-30"
@@ -684,7 +684,7 @@
                         ]
                     },
                     "startDate": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "format": "date",
                         "title": "The startDate Schema",
                         "examples": [
@@ -693,7 +693,7 @@
                         ]
                     },
                     "endDate": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "title": "The endDate Schema",
                         "examples": [
                             "2021-05-30",
@@ -1112,7 +1112,7 @@
                         ]
                     },
                     "startDate": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "format": "date",
                         "default": "",
                         "title": "The startDate Schema",
@@ -1121,7 +1121,7 @@
                         ]
                     },
                     "endDate": {
-                        "type": "string",
+                        "type": ["string", "null"],
                         "default": "",
                         "title": "The endDate Schema",
                         "examples": [

--- a/utils.typ
+++ b/utils.typ
@@ -27,6 +27,9 @@
 }
 
 #let strpdate(isodate) = {
+    if isodate == none {
+        return none
+    }
     let date = ""
     if lower(isodate) != "present" {
         date = datetime(
@@ -39,4 +42,16 @@
         date = "Present"
     }
     return date
+}
+
+#let daterange(start, end) = {
+    if start != none and end != none [
+        #start #sym.dash.en #end
+    ]
+    if start == none and end != none [
+        #end
+    ]
+    if start != none and end == none [
+        #start #sym.dash.en Present
+    ]
 }


### PR DESCRIPTION
Allows the user to omit dates in date ranges using the logic:

```
#let daterange(start, end) = {
    if start != none and end != none [
        #start #sym.dash.en #end
    ]
    if start == none and end != none [
        #end
    ]
    if start != none and end == none [
        #start #sym.dash.en Present
    ]
}
```