### PR TITLE
Added optionality of edu.area

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -178,7 +178,11 @@
                     *#edu.institution* #h(1fr) *#edu.location* \
                 ]
                 // Line 2: Degree and Date
-                #text(style: "italic")[#edu.studyType in #edu.area] #h(1fr)
+                #if edu.area != none [
+                    #text(style: "italic")[#edu.studyType in #edu.area] #h(1fr)
+                ] else [
+                    #text(style: "italic")[#edu.studyType] #h(1fr)
+                ]
                 #utils.daterange(start, end) \
                 #eval(edu-items, mode: "markup")
             ]


### PR DESCRIPTION
*Awesome template, thank you!*

Without this change, the "in" is always visible, even when `edu.area` is empty.
This is useful for secondary education stages like "High School Diploma" for example or similar...